### PR TITLE
Fix for allow_provider_download

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -54,7 +54,7 @@ protobuf_deps()
 load("@tf_modules//terraform:versions.bzl", "register_terraform_version")
 
 register_terraform_version(
-    "1.2.9",
+    "1.7.5",
     default = True,
 )
 

--- a/rules/terraform.bzl
+++ b/rules/terraform.bzl
@@ -121,7 +121,8 @@ disable_checkpoint = true
       TF=$(pwd)/$TF_RELATIVE
       cd $WORKING_DIR
 
-      mkdir .terraform
+      mkdir -p .terraform
+      mkdir -p terraform.d/plugins
       touch $TF_LOCK # ensure the lock file exists (older Terraform versions don't create it)
 
       $TF init -backend=false

--- a/tests/allow_provider_download/BUILD
+++ b/tests/allow_provider_download/BUILD
@@ -1,0 +1,22 @@
+load("@tf_modules//rules:module.bzl", "terraform_module")
+load("@tf_modules//rules:terraform.bzl", "terraform_working_directory")
+
+terraform_module(
+    name = "provider",
+    srcs = ["main.tf"],
+    visibility = ["//visibility:public"],
+)
+
+terraform_working_directory(
+    name = "terraform",
+    module = ":provider",
+    allow_provider_download = True,
+)
+
+sh_test(
+    name = "terraform_test",
+    size = "small",
+    srcs = ["test.sh"],
+    data = [":terraform"],
+)
+

--- a/tests/allow_provider_download/main.tf
+++ b/tests/allow_provider_download/main.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    local = {
+      source = "hashicorp/local"
+      version = ">= 2.4.1"
+    }
+  }
+}
+
+resource "local_file" "foo" {
+  content  = "foo!"
+  filename = "${path.module}/foo.bar"
+}

--- a/tests/allow_provider_download/test.sh
+++ b/tests/allow_provider_download/test.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+OUT=$(./tests/allow_provider_download/terraform plan -no-color)
+if [ $? -ne 0 ];
+then
+    echo 'Plan failed';
+    exit 1
+fi
+
+PASS=1
+
+function expect_output() {
+    if [[ "$OUT" != *"$1"* ]]; then
+        echo "FAIL: Expected text '$1'"
+        PASS=0
+    fi   
+}
+
+expect_output "+ resource \"local_file\" \"foo\" {"
+expect_output "1 to add"
+
+if [[ $PASS == 0 ]]; then
+    echo "$OUT"
+    exit 1
+fi


### PR DESCRIPTION
When enabling download of providers, but not also providing a provider by target, builds would fail because the "terraform.d/plugins" directory was missing.

This change fixes this issue by creating the directory as needed.

Additional changes:
* Test created for the above
* The default version for testing is bumped to the most recent Terraform version.
* Calls to mkdir use "-p" to avoid output when the directory already exists.